### PR TITLE
web-ui: replace textarea tag with codemirror.

### DIFF
--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -38,10 +38,6 @@
         flex-direction: column;
       }
     }
-
-    .CodeMirror-wrap {
-      word-break: break-word;
-    }
   </style>
 </head>
 

--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -38,6 +38,10 @@
         flex-direction: column;
       }
     }
+
+    .CodeMirror-wrap {
+      word-break: break-word;
+    }
   </style>
 </head>
 
@@ -79,6 +83,7 @@
       mode: 'text/x-ocaml',
       smartIndent: true,
       lineNumbers: true,
+      lineWrapping: true,
     });
 
     editor.setSize('100%', '100%');

--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -6,6 +6,18 @@
   <title>OCamlFormat configurator</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <script type="text/javascript" src="./ocamlformat.bc.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/codemirror.min.css"
+    integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/codemirror.min.js"
+    integrity="sha512-n7rucz/qOiYAkYK1CVKuqygMAnohil8Rg6kKAv0IsF2xnHUhnVyD5K9GO25OUvc+WEVZVu+NIYLblIUpkBMNvQ=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/mode/mllike/mllike.min.js"
+    integrity="sha512-vN71zIsnXQRCsHoCiPbobn2ROoOaOfsuY2PW5Dh4Pl7zFVXJ/IQFxT8yCmZjdyehWrZPLsf+xL75jQp+T++Cnw=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/addon/edit/matchbrackets.min.js"
+    integrity="sha512-GSYCbN/le5gNmfAWVEjg1tKnOH7ilK6xCLgA7c48IReoIR2g2vldxTM6kZlN6o3VtWIe6fHu/qhwxIt11J8EBA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <style>
     * {
       box-sizing: border-box;
@@ -13,6 +25,7 @@
     }
 
     .flex-row {
+      width: 100%;
       display: flex;
       flex-direction: row;
     }
@@ -20,6 +33,7 @@
     .flex-column {
       display: flex;
       flex-direction: column;
+      flex-basis: 100%;
     }
 
     @media (max-width: 800px) {
@@ -48,7 +62,8 @@
           <label for="code">OCaml code</label>
           <button type="button" id="format">format</button>
         </div>
-        <textarea name="code" id="code" rows="50" cols="120" spellcheck="false"></textarea>
+        <textarea name="code" id="code" class="language-mllike" spellcheck="false"></textarea>
+        </textarea>
       </div>
       <div class="flex-column">
         <div class="flex-row">
@@ -63,6 +78,18 @@
       </div>
     </div>
   </div>
+  <script>
+    const editor = CodeMirror.fromTextArea(document.getElementById('code'), {
+      smartIndent: true,
+      mode: 'text/x-ocaml',
+      lineNumbers: true,
+      matchBrackets: true
+    });
+
+    editor.setSize("100%", "100%");
+
+    editor.save();
+  </script>
 </body>
 
 </html>

--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -15,9 +15,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/mode/mllike/mllike.min.js"
     integrity="sha512-vN71zIsnXQRCsHoCiPbobn2ROoOaOfsuY2PW5Dh4Pl7zFVXJ/IQFxT8yCmZjdyehWrZPLsf+xL75jQp+T++Cnw=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/addon/edit/matchbrackets.min.js"
-    integrity="sha512-GSYCbN/le5gNmfAWVEjg1tKnOH7ilK6xCLgA7c48IReoIR2g2vldxTM6kZlN6o3VtWIe6fHu/qhwxIt11J8EBA=="
-    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <style>
     * {
       box-sizing: border-box;
@@ -78,11 +75,10 @@
     </div>
   </div>
   <script>
-    const editor = CodeMirror.fromTextArea(document.getElementById('code'), {
-      smartIndent: true,
+    window.editor = CodeMirror.fromTextArea(document.getElementById('code'), {
       mode: 'text/x-ocaml',
+      smartIndent: true,
       lineNumbers: true,
-      matchBrackets: true
     });
 
     editor.setSize('100%', '100%');

--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -63,7 +63,6 @@
           <button type="button" id="format">format</button>
         </div>
         <textarea name="code" id="code" class="language-mllike" spellcheck="false"></textarea>
-        </textarea>
       </div>
       <div class="flex-column">
         <div class="flex-row">
@@ -86,7 +85,7 @@
       matchBrackets: true
     });
 
-    editor.setSize("100%", "100%");
+    editor.setSize('100%', '100%');
 
     editor.save();
   </script>

--- a/bin/web-ui/main.ml
+++ b/bin/web-ui/main.ml
@@ -425,8 +425,12 @@ let onload _event =
           let () =
             match code_formatted with
             | Ok code_formatted ->
+                let escaped =
+                  Js.to_string (Js.escape (Js.string code_formatted))
+                in
                 Js.Unsafe.eval_string
-                  (Printf.sprintf "editor.doc.setValue(`%s`)" code_formatted)
+                  (Printf.sprintf "editor.doc.setValue(unescape('%s'))"
+                     escaped )
             | Error _e -> ()
           in
           Js._true ) ;

--- a/bin/web-ui/main.ml
+++ b/bin/web-ui/main.ml
@@ -425,6 +425,11 @@ let onload _event =
             match code_formatted with
             | Ok code_formatted ->
                 code_input##.value := Js.string code_formatted
+                (* somehow, we have to replace above line with
+                let formatted = Js.string code_formatted in
+                (* editor is attached to window object *)
+                editor.doc.setValue(formatted)
+                *)
             | Error _e -> ()
           in
           Js._true ) ;


### PR DESCRIPTION
Hey if you guys are interested, I've added a web text editor to make viewing bearable, please note that I'm no html/css expert.

It looks like this:

![image](https://user-images.githubusercontent.com/11157420/178203762-f361a0df-591f-44fe-a4ce-e9c4e9147d2a.png)

Technical details:
- Replace textarea with [codemirror v5](https://codemirror.net/5/)
- Minor style changes to accommodate the editor


If this doesn't align with your goal feel free to close this pr.

Thank you for your amazing work.

