### PR TITLE
Improve ocaml-formatter web-ui styles

### DIFF
--- a/bin/web-ui/index.html
+++ b/bin/web-ui/index.html
@@ -15,69 +15,43 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.6/mode/mllike/mllike.min.js"
     integrity="sha512-vN71zIsnXQRCsHoCiPbobn2ROoOaOfsuY2PW5Dh4Pl7zFVXJ/IQFxT8yCmZjdyehWrZPLsf+xL75jQp+T++Cnw=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <style>
-    .flex-row {
-      width: 100%;
-      display: flex;
-      flex-direction: row;
-      padding: 3px;
-    }
-
-    .flex-column {
-      display: flex;
-      flex-direction: column;
-      flex-basis: 100%;
-      padding: 3px;
-    }
-
-    @media (max-width: 800px) {
-      .flex-row {
-        flex-direction: column;
-      }
-    }
-
-    .CodeMirror {
-      border: 1px solid #aaa;
-      height: 100%;
-      width: 100%;
-    }
-
-  </style>
+  <link rel="stylesheet" href="./styles/reset.css">
+  <link rel="stylesheet" href="./styles/index.css">
 </head>
 
 <body>
-  <div class="flex-column">
-    <div class="flex-row">
-      <div style="font-size: larger; font-weight: 700;">
-        OCamlFormat configurator
-      </div>
-      <div style="margin-left: auto;">
-        Made by <a href="https://ahrefs.com">Ahrefs</a> -
-        Check our <a href="https://ahrefs.com/jobs">job openings</a> -
-        Code available on <a href="https://github.com/ahrefs/ocamlformat/tree/ahrefs/web-ui/bin/web-ui">github</a>
-      </div>
-    </div>
-    <div class="flex-row">
-      <div class="flex-column">
-        <div class="flex-row">
+  <header>
+    <h1>OCamlFormat configurator</h1>
+  </header>
+  <main>
+    <div class="flex-column">
+      <div class="flex-row">
+        <h2>
           <label for="code">OCaml code</label>
           <button type="button" id="format">format</button>
-        </div>
-        <textarea name="code" id="code" class="language-mllike" spellcheck="false"></textarea>
+        </h2>
       </div>
-      <div class="flex-column">
-        <div class="flex-row">
-          <label for="config">OCamlFormat config
-          </label>
-          (<a
-            href="https://raw.githubusercontent.com/ocaml-ppx/ocamlformat/main/ocamlformat-help.txt">documentation</a>)
-        </div>
-        <textarea name="config" id="config" rows="8" cols="80" placeholder="profile=default"
-          spellcheck="false"></textarea>
-        <div id="options"></div>
-      </div>
+      <textarea name="code" id="code" class="language-mllike" spellcheck="false"></textarea>
     </div>
-  </div>
+    <div class="flex-column">
+      <h2>
+        <label for="config">OCamlFormat config
+        </label>
+        (<a
+          href="https://raw.githubusercontent.com/ocaml-ppx/ocamlformat/main/ocamlformat-help.txt">documentation</a>)
+      </h2>
+      <textarea name="config" id="config" rows="8" cols="80" placeholder="profile=default"
+        spellcheck="false"></textarea>
+      <div id="options"></div>
+    </div>
+  </main>
+  <footer>
+    <p>
+      Made by <a href="https://ahrefs.com">Ahrefs</a> -
+      Check our <a href="https://ahrefs.com/jobs">job openings</a> -
+      Code available on <a href="https://github.com/ahrefs/ocamlformat/tree/ahrefs/web-ui/bin/web-ui">github</a>
+    </p>
+  </footer>
   <script>
     window.editor = CodeMirror.fromTextArea(document.getElementById('code'), {
       mode: 'text/x-ocaml',

--- a/bin/web-ui/styles/index.css
+++ b/bin/web-ui/styles/index.css
@@ -49,6 +49,11 @@ a:hover {
   color: var(--link-hover-color);
 }
 
+button {
+  font-size: 1rem;
+  cursor: pointer;
+}
+
 main {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -63,6 +68,7 @@ textarea,
 
 textarea {
   resize: vertical;
+  font-size: 1rem;
 }
 
 .CodeMirror {
@@ -71,4 +77,21 @@ textarea {
 
 #options {
   margin-top: 1.5rem;
+}
+
+#options > div {
+  margin-bottom: .3rem;
+}
+
+#options > div label {
+  min-width: 18rem;
+  display: inline-block;
+}
+
+#options > div select {
+  width: 8rem;
+}
+
+#options > div input {
+  width: 7.5rem;
 }

--- a/bin/web-ui/styles/index.css
+++ b/bin/web-ui/styles/index.css
@@ -1,0 +1,74 @@
+/* Base */
+:root {
+  --text-color: rgb(0, 0, 0);
+  --bg-color: rgb(244, 245, 246);
+  --link-color: rgb(5, 74, 218);
+  --link-hover-color: rgb(255, 136, 0);
+  --border-color: rgb(170, 170, 170);
+}
+
+body {
+  font-size: 18px;
+  padding: 0 2rem;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+header,
+footer {
+  text-align: center;
+}
+
+header {
+  padding: 1rem 0 3rem 0;
+}
+
+footer {
+  padding: 5rem 0 1rem 0;
+}
+
+h1 {
+  font-size: 2rem;
+  line-height: 2.2rem;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 1.3rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+a {
+  color: var(--link-color);
+  transition: all 100ms ease-in-out;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--link-hover-color);
+}
+
+main {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 2rem;
+}
+
+textarea,
+.CodeMirror {
+  width: 100%;
+  border: 1px solid var(--border-color);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.CodeMirror {
+  height: 100%;
+}
+
+#options {
+  margin-top: 1.5rem;
+}

--- a/bin/web-ui/styles/reset.css
+++ b/bin/web-ui/styles/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}


### PR DESCRIPTION
Issue: #2 

This PR consists of web-ui improvements:
1. Styles have been moved to separate files:
- reset.css - сommonly used reset browser styles https://meyerweb.com/eric/tools/css/reset/
- index.css - base and layout styles
2. Changed `flex` to `grid`. Result is the same but with fewer styles.
3. Layout was slightly changed:
- ** OCamlFormat configurator ** is now in the `h1` tag in `<header/>`
- ** Made by Ahrefs- Check our job openings - Code available on github ** placed in `<footer />`

Before:

![OCamlFormat-configurator-before](https://user-images.githubusercontent.com/5857746/183098224-49d9e4d5-6f5f-4e4b-b022-978cf785eaeb.png)

After:

![OCamlFormat-configurator-after](https://user-images.githubusercontent.com/5857746/183098250-6d316fd0-bd4e-4014-bc97-a7ad92de9e69.png)
